### PR TITLE
Fix/006 use current user in replies

### DIFF
--- a/src/features/email/components/index.ts
+++ b/src/features/email/components/index.ts
@@ -1,2 +1,1 @@
 export { EmailMessage } from './EmailMessage'
-export { EmailReplyBox } from './EmailReplyBox'

--- a/src/features/email/context.tsx
+++ b/src/features/email/context.tsx
@@ -13,7 +13,7 @@ interface EmailState {
 type EmailAction = 
   | { type: "SELECT_THREAD"; threadId: string }
   | { type: "ASSIGN_THREAD"; threadId: string; assigneeIds: string[] }
-  | { type: "ADD_REPLY"; threadId: string; message: string }
+  | { type: "ADD_REPLY"; threadId: string; message: string; sender: User }
 
 interface EmailContextType {
   state: EmailState
@@ -39,6 +39,8 @@ function emailReducer(state: EmailState, action: EmailAction): EmailState {
         )
       }
     case "ADD_REPLY": {
+      if (!action.sender) return state
+      
       const timestamp = new Date().toISOString()
       return {
         ...state,
@@ -52,13 +54,10 @@ function emailReducer(state: EmailState, action: EmailAction): EmailState {
                   ...thread.messages,
                   {
                     id: Date.now().toString(),
-                    from: {
-                      name: "Me",
-                      email: "me@example.com",
-                    },
+                    from: action.sender,
                     to: [{
                       name: thread.name,
-                      email: thread.email
+                      email: thread.email,
                     }],
                     content: action.message,
                     timestamp

--- a/src/features/email/types.ts
+++ b/src/features/email/types.ts
@@ -1,3 +1,13 @@
+import { User } from "@/features/user/types"
+
+export interface EmailMessage {
+  id: string
+  from: User
+  to: User[]
+  content: string
+  timestamp: string
+}
+
 export interface Mail {
   name: string
   email: string
@@ -6,19 +16,4 @@ export interface Mail {
   teaser: string
   messages: EmailMessage[]
   assignees: string[]
-}
-
-export interface EmailMessage {
-  id: string
-  from: {
-    name: string
-    email: string
-    avatar?: string
-  }
-  to: Array<{
-    name: string
-    email: string
-  }>
-  content: string
-  timestamp: string
 } 

--- a/src/features/thread/components/ThreadReplyBox.tsx
+++ b/src/features/thread/components/ThreadReplyBox.tsx
@@ -1,24 +1,16 @@
 import * as React from "react"
 import { cn } from "@/lib/utils"
-import { useEmail } from "../context"
+import { useThread } from "../context"
 
-interface EmailReplyBoxProps {
-  threadId: string
-}
-
-export function EmailReplyBox({ threadId }: EmailReplyBoxProps) {
+export function ThreadReplyBox() {
+  const { addReply } = useThread()
   const [message, setMessage] = React.useState("")
-  const { dispatch } = useEmail()
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     if (!message.trim()) return
 
-    dispatch({
-      type: "ADD_REPLY",
-      threadId,
-      message: message.trim()
-    })
+    addReply(message.trim())
     setMessage("")
   }
 

--- a/src/features/thread/components/ThreadView.tsx
+++ b/src/features/thread/components/ThreadView.tsx
@@ -1,7 +1,7 @@
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Card, CardContent, CardHeader } from "@/components/ui/card"
 import { EmailMessage } from "@/features/email/components/EmailMessage"
-import { EmailReplyBox } from "@/features/email/components/EmailReplyBox"
+import { ThreadReplyBox } from "@/features/thread/components/ThreadReplyBox"
 import { useThread } from "../context"
 import { EmptyState } from "./EmptyState"
 import { formatDate } from "@/utils/date"
@@ -36,7 +36,7 @@ export function ThreadView() {
 
       <Card>
         <CardContent className="p-4">
-          <EmailReplyBox threadId={currentThread.email} />
+          <ThreadReplyBox />
         </CardContent>
       </Card>
     </div>

--- a/src/features/thread/context.tsx
+++ b/src/features/thread/context.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { Mail } from "@/features/email/types"
 import { useEmail } from "@/features/email/context"
+import { useUser } from "../user/context"
 
 interface ThreadContextType {
   currentThread: Mail | undefined
@@ -12,6 +13,7 @@ const ThreadContext = React.createContext<ThreadContextType | undefined>(undefin
 
 export function ThreadProvider({ children }: { children: React.ReactNode }) {
   const { state, dispatch } = useEmail()
+  const { state: { user } } = useUser()
   const currentThread = state.threads.find(
     (thread) => thread.email === state.selectedThreadId
   )
@@ -27,14 +29,15 @@ export function ThreadProvider({ children }: { children: React.ReactNode }) {
       })
     },
     addReply: (message: string) => {
-      if (!currentThread) return
+      if (!currentThread || !user) return
       dispatch({
         type: "ADD_REPLY",
         threadId: currentThread.email,
-        message
+        message,
+        sender: user
       })
     }
-  }), [currentThread, dispatch])
+  }), [currentThread, user, dispatch])
 
   return (
     <ThreadContext.Provider value={value}>

--- a/src/features/user/types.ts
+++ b/src/features/user/types.ts
@@ -2,5 +2,5 @@ export interface User {
   name: string
   email: string
   avatar?: string
-  role: string
+  role?: string
 }


### PR DESCRIPTION
This pull request includes several changes to the email and thread components, focusing on refactoring and improving the handling of replies by incorporating user information. The most important changes involve updating the `EmailMessage` interface, modifying the `emailReducer` function, and renaming the `EmailReplyBox` component.

### Refactoring and Improvements:

* [`src/features/email/types.ts`](diffhunk://#diff-44b12e6254b0dc55feb733880d3f793a4a55d233661a0efc2a17b13f71e37f09R1-R10): Updated the `EmailMessage` interface to include a `User` type for the `from` and `to` fields. Removed the previous `EmailMessage` definition. [[1]](diffhunk://#diff-44b12e6254b0dc55feb733880d3f793a4a55d233661a0efc2a17b13f71e37f09R1-R10) [[2]](diffhunk://#diff-44b12e6254b0dc55feb733880d3f793a4a55d233661a0efc2a17b13f71e37f09L10-L24)

* [`src/features/email/context.tsx`](diffhunk://#diff-31c98b3e21914b8eaf85de134f1858cd40362270f91e8318f2529bbe7dc62556L16-R16): Modified the `ADD_REPLY` action to include a `sender` field of type `User`. Updated the `emailReducer` function to handle the `sender` field and ensure it is provided. [[1]](diffhunk://#diff-31c98b3e21914b8eaf85de134f1858cd40362270f91e8318f2529bbe7dc62556L16-R16) [[2]](diffhunk://#diff-31c98b3e21914b8eaf85de134f1858cd40362270f91e8318f2529bbe7dc62556R42-R43) [[3]](diffhunk://#diff-31c98b3e21914b8eaf85de134f1858cd40362270f91e8318f2529bbe7dc62556L55-R60)

### Component Renaming and Refactoring:

* [`src/features/thread/components/ThreadReplyBox.tsx`](diffhunk://#diff-865c4cdd6ab50027239f1db47bdc5d52ce4d39b0cde917b373ed502e811dca87L3-R13): Renamed from `EmailReplyBox.tsx` and refactored to use the `useThread` context instead of `useEmail`. Removed the `threadId` prop and updated the `handleSubmit` function to use the `addReply` method from the `useThread` context.

* [`src/features/thread/components/ThreadView.tsx`](diffhunk://#diff-2d077661119743f1ed1b7b233d2378448914dbeb72d43fd231f2461d83ff888fL4-R4): Updated to use the renamed `ThreadReplyBox` component instead of `EmailReplyBox`. [[1]](diffhunk://#diff-2d077661119743f1ed1b7b233d2378448914dbeb72d43fd231f2461d83ff888fL4-R4) [[2]](diffhunk://#diff-2d077661119743f1ed1b7b233d2378448914dbeb72d43fd231f2461d83ff888fL39-R39)

### Context Updates:

* [`src/features/thread/context.tsx`](diffhunk://#diff-761f4b47bf62700f671bd0fa2aa64a764c9c896d9cfcea42ed54661f92e75067R4): Integrated `useUser` context to access the current user and include the user information when adding a reply. Updated the `addReply` method to include the `sender` field. [[1]](diffhunk://#diff-761f4b47bf62700f671bd0fa2aa64a764c9c896d9cfcea42ed54661f92e75067R4) [[2]](diffhunk://#diff-761f4b47bf62700f671bd0fa2aa64a764c9c896d9cfcea42ed54661f92e75067R16) [[3]](diffhunk://#diff-761f4b47bf62700f671bd0fa2aa64a764c9c896d9cfcea42ed54661f92e75067L30-R40)

### Minor Changes:

* [`src/features/user/types.ts`](diffhunk://#diff-d61be9f7e9f8a3b33c2dde8dc033e0f3ecc5f6fad616618600b60e3214891c2fL5-R5): Made the `role` field in the `User` interface optional.

* [`src/features/email/components/index.ts`](diffhunk://#diff-dd2df910f01ca990c0569710d5930e8c03b1f3e683af3ab7c1b2b84749203e70L2): Removed the export of the `EmailReplyBox` component.